### PR TITLE
Feature/track-view-controller

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
+++ b/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
@@ -88,7 +88,15 @@ public class AnalyticsCollectionManager {
 // MARK: - Logging
 
 public extension AnalyticsCollectionManager {
-        
+    
+    func track(viewController: UIViewController?) {
+        let screenClass = String(describing: type(of: viewController))
+        let screenName = viewController?.title
+        DispatchQueue.main.async { [weak self] in
+            self?.logs.append(.init(screenClass: screenClass, screenName: screenName))
+        }
+    }
+    
     func track(screenClass: String?, screenName: String?) {
         guard let screenClass = screenClass else { return }
         DispatchQueue.main.async { [weak self] in

--- a/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
+++ b/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
@@ -89,7 +89,7 @@ public class AnalyticsCollectionManager {
 
 public extension AnalyticsCollectionManager {
     
-    func track(viewController: UIViewController?) {
+    func track(viewController: UIViewController) {
         let screenClass = String(describing: type(of: viewController))
         let screenName = viewController?.title
         DispatchQueue.main.async { [weak self] in

--- a/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
+++ b/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
@@ -23,8 +23,8 @@ public struct LogItem: CustomStringConvertible {
 
     static let dateFormatter = ISO8601DateFormatter()
 
-    init(screenName: String, screenClass: String?) {
-        self.init(type: .screen, name: screenName, value: screenClass)
+    init(screenClass: String, screenName: String?) {
+        self.init(type: .screen, name: screenClass, value: screenName)
     }
     
     init(event: String, parameters: [String: Any]?) {
@@ -88,11 +88,11 @@ public class AnalyticsCollectionManager {
 // MARK: - Logging
 
 public extension AnalyticsCollectionManager {
-    
-    func track(screenName: String?, screenClass: String?) {
-        guard let screenName = screenName else { return }
+        
+    func track(screenClass: String?, screenName: String?) {
+        guard let screenClass = screenClass else { return }
         DispatchQueue.main.async { [weak self] in
-            self?.logs.append(.init(screenName: screenName, screenClass: screenClass))
+            self?.logs.append(.init(screenClass: screenClass, screenName: screenName))
         }
     }
 

--- a/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
+++ b/Sources/Collar/Classes/Collar/AnalyticsCollectionManager.swift
@@ -91,7 +91,7 @@ public extension AnalyticsCollectionManager {
     
     func track(viewController: UIViewController) {
         let screenClass = String(describing: type(of: viewController))
-        let screenName = viewController?.title
+        let screenName = viewController.title
         DispatchQueue.main.async { [weak self] in
             self?.logs.append(.init(screenClass: screenClass, screenName: screenName))
         }


### PR DESCRIPTION
New feature: `track UIViewController`
Add an option to track `UIViewController` by tracking `Class` and `title`.

Update: `track(screenClass: String?, screenName: String?)`
- use `screenClass` as LogItem.name as it is less likely to be empty
 - use `screenName` as LogItem.value 